### PR TITLE
Add mechanism to disable calmon sequences

### DIFF
--- a/scripts/load.records
+++ b/scripts/load.records
@@ -594,9 +594,11 @@ load_400() {
         make_AI $site
         aprams="UUT=${HOST},SITE=${site},CHG=${has_ch_gains}"
         dblr '"db/adc-'${is_adc}'.db","'$aprams'"'
-        if [ "x${calmon}" != "xnone" ]; then
-            echo >>/tmp/st_post.cmd "seq ${calmon} \"uut=${HOST},site=${site},rdis=${CALMON_RDIS:-0},verbose=${CALMON_VERBOSE:-0}\""
-        fi
+	if [ "$DISABLE_CALMON" != "1" ]; then
+	    if [ "x${calmon}" != "xnone" ]; then
+		echo >>/tmp/st_post.cmd "seq ${calmon} \"uut=${HOST},site=${site},rdis=${CALMON_RDIS:-0},verbose=${CALMON_VERBOSE:-0}\""
+	    fi
+	fi
         ONSETTRANSIENT=${ONSETTRANSIENT:-1}
     fi
 


### PR DESCRIPTION
Calmon sequences can now be disabled by setting env variable DISABLE_CALMON=1

This should be set in epics.sh and will stop calmon sequences being built into the st.cmd that is run by acq400ioc.