### PR TITLE
Bugfix: MODE:CONTINUOUS:SC signed overflow

### DIFF
--- a/db/transient.db
+++ b/db/transient.db
@@ -48,9 +48,10 @@ record(fanout, "${UUT}:MODE:CONTINUOUS:STATE_f") {
 #        field(FLNK, "$(UUT):0:SLOWMON:EN:c PP")
 }
 
-record(longin, "${UUT}:MODE:CONTINUOUS:SC") {
+record(ai, "${UUT}:MODE:CONTINUOUS:SC") {
 	field(DTYP, "Soft Channel")
 	field(DESC, "samples streamed so far")
+    field(PREC, "0")
 }
 
 


### PR DESCRIPTION
This was set as a longin which is 32-bit signed. Would quickly overflow on a long stream, go negative then get stuck forever at -1.

Setting to ai (a 64-bit float) with PREC 0 which lets us pretend it's an integer for display.