### PR TITLE
Fixed MGTLIST PV only having one site

### DIFF
--- a/scripts/load.mgt400
+++ b/scripts/load.mgt400
@@ -114,7 +114,7 @@ for SITE in 13 12 11 10; do
 	    case ${mt} in
 	    9[01234])
 	        MGTPORTS=$(($MGTPORTS+1))
-	        [ ! -z $MGTLIST ] && MGTLIST="$MGTLIST,"
+	        [ ! -z "${MGTLIST}" ] && MGTLIST="${MGTLIST}\\,"
 	        MGTLIST="$MGTLIST$id"
 		load_mgt400 $SITE $id;;
 	    97)
@@ -125,7 +125,7 @@ for SITE in 13 12 11 10; do
 	fi
 done
 
-dblr '"db/acq2106_mgtports.db","UUT='${HOST}',MGTPORTS='${MGTPORTS}',MGTLIST='''${MGTLIST}'''"'
+dblr '"db/acq2106_mgtports.db","UUT='${HOST}',MGTPORTS='${MGTPORTS}',MGTLIST='${MGTLIST}'"'
 
 if [ "$mt" != "z7io" ]; then
 # SFP1 at 4291


### PR DESCRIPTION
	modified:   scripts/load.mgt400
	
load.mgt400 builds a comma separated list of MGT sites however the command breaks dbLoadRecords so MGTLIST always equals A

`dbLoadRecords("db/acq2106_mgtports.db","UUT=acq2106_130,MGTPORTS=2,MGTLIST=A,B" )`

the B becomes a macro name with no value